### PR TITLE
chore: ensure systemd services are stopped/disabled on uninstall

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
       vars:
         unit_config:
           - name: "{{ name }}"
-            state: absent
+            state: stopped
             enabled: false
         perform_uninstall: true
       when: setup_mode == 'systemd'


### PR DESCRIPTION
* currently the uninstall of systemd based services set the wrong stoppage state - this change resolves that issue