### PR TITLE
feat: add systemd network accounting

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Lint yaml and Ansible configs
         run: |
           python -m pip install --upgrade pip
-          pip install ansible-lint==24.12.2 yamllint==1.35.1
+          pip install ansible-lint==24.12.2 yamllint==1.35.1 ansible-core==2.16.3
           yamllint --config-file ./tests/yaml-lint.yml .
           ansible-lint --config-file ./tests/ansible-lint.yml .
   molecule:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Configure and operate a basic cloud-native service: running anything from cypto 
 |    _binary_strip_components_     | Strip NUMBER leading components/directories from file names on extraction | `0` |
 |     _destination_directory_     |             directory where the binary file will be placed after downloading/extracting              |    `/usr/local/bin`    |
 |   _systemd_   |    custom service type & unit, service and install properties    |     `{}`      |
+|   _systemd.enable_network_accounting_   |    enable IP accounting for network traffic tracking    |     `true`      |
 
 ### Kubernetes (k8s)
 
@@ -123,6 +124,7 @@ collections:
             ingressPort: 51820
             servicePort: 51820
         systemd:
+          enable_network_accounting: true
           service_properties:
             ExecStop: /usr/local/bin/wg-quick down wg0
             Restart: on-failure

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -80,10 +80,12 @@ _systemd_environment_directive: ''
 # binary_file_name_override:
 
 systemd: {}
-# service_type: e.g. simple, oneshot, forking (https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Type=)
+# service_type: e.g. simple, oneshot, forking
+# (https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Type=)
 # unit_properties: {}
 # service_properties: {}
 # install_properties: {}
+# enable_network_accounting: true
 
 systemd_environment_directive: ""
 

--- a/tasks/common/custom-facts.yml
+++ b/tasks/common/custom-facts.yml
@@ -59,6 +59,7 @@
       CPUQuota: "{{ cpus }}%"
       MemoryHigh: "{{ memory }}"
       Restart: "{{ restart_policy }}"
+      IPAccounting: "{{ 'yes' if systemd.enable_network_accounting | default(true) else omit }}"
     _default_unit_install:
       WantedBy: multi-user.target
     _custom_unit_properties: "{{ systemd.unit_properties | default({}) }}"

--- a/tasks/common/custom-facts.yml
+++ b/tasks/common/custom-facts.yml
@@ -50,16 +50,20 @@
     _default_unit_info:
       Wants: network-online.target
       After: syslog.target network-online.target
-    _default_unit_service:
-      Type: "{{ systemd.service_type | default('simple') }}"
-      ExecStart: "{{ command | default(name) }}"
-      User: "{{ user | default(ansible_user) }}"
-      Group: "{{ group | default(user) | default(ansible_user) }}"
-      Environment: "{{ _systemd_environment_directive }}"
-      CPUQuota: "{{ cpus }}%"
-      MemoryHigh: "{{ memory }}"
-      Restart: "{{ restart_policy }}"
-      IPAccounting: "{{ 'yes' if systemd.enable_network_accounting | default(true) else omit }}"
+    _default_unit_service: >-
+      {{
+        {
+          'Type': (systemd.service_type | default('simple')),
+          'ExecStart': (command | default(name)),
+          'User': (user | default(ansible_user)),
+          'Group': (group | default(user) | default(ansible_user)),
+          'Environment': _systemd_environment_directive,
+          'CPUQuota': (cpus | string ~ '%'),
+          'MemoryHigh': memory,
+          'Restart': restart_policy
+        }
+        | combine((systemd.enable_network_accounting | default(true)) | ternary({'IPAccounting': 'yes'}, {}), recursive=True)
+      }}
     _default_unit_install:
       WantedBy: multi-user.target
     _custom_unit_properties: "{{ systemd.unit_properties | default({}) }}"

--- a/tests/molecule/systemd-full/converge.yml
+++ b/tests/molecule/systemd-full/converge.yml
@@ -40,3 +40,5 @@
           prometheus:
             ingressPort: 9090
             servicePort: 9090
+        systemd:
+          enable_network_accounting: true

--- a/tests/molecule/systemd-full/tests/test_systemd_full.py
+++ b/tests/molecule/systemd-full/tests/test_systemd_full.py
@@ -78,3 +78,13 @@ def test_iptables_prometheus_port(host):
 
     # Verify that the rule allowing TCP traffic on port 9090 exists
     assert "9090" in iptables_output.stdout, "The iptables rule for port 9090 is missing."
+
+def test_systemd_ip_accounting(host):
+    """Verify that IP accounting is enabled and working."""
+    service_content = host.file("/etc/systemd/system/test-service.service").content_string
+    assert "IPAccounting=yes" in service_content, "IPAccounting directive is missing from the service file."
+
+    # Verify systemd tracks network data
+    accounting_output = host.run("systemctl show test-service --property=IPIngressBytes,IPEgressBytes")
+    assert accounting_output.rc == 0, "Failed to get IP accounting data from systemd."
+    assert "IPIngressBytes=" in accounting_output.stdout and "IPEgressBytes=" in accounting_output.stdout, "IP accounting data is not available."


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce `systemd.enable_network_accounting` to set `IPAccounting=yes` in services; update docs, tests, and CI deps.
> 
> - **Systemd**:
>   - Add `systemd.enable_network_accounting` (default `true`) to enable IP accounting.
>   - Set `IPAccounting=yes` in generated unit when enabled (`tasks/common/custom-facts.yml`).
>   - Document option and usage in `README.md` and `defaults/main.yml` comments; example shows `systemd.enable_network_accounting: true`.
> - **Tests**:
>   - `tests/molecule/systemd-full`: include `systemd.enable_network_accounting: true` in `converge.yml`.
>   - Add `test_systemd_ip_accounting` to verify `IPAccounting=yes` and `systemctl show` ingress/egress bytes.
> - **CI**:
>   - Lint job installs `ansible-core==2.16.3` in addition to existing linters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 115454c5078006c9877660b896be3e7f8f25a162. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->