### PR TITLE
chore: make downloadable binary urls optional for service deployments

### DIFF
--- a/tasks/common/download-binary.yml
+++ b/tasks/common/download-binary.yml
@@ -41,10 +41,12 @@
   register: binary_override_file_stat
   when:
     - binary_file_name_override is defined
+    - binary_url | default('', true) | length > 0
 
 - name: Fail if override binary file [{{ binary_file_name_override }}] is missing at [{{ destination_directory }}]
   ansible.builtin.fail:
     msg: "The binary file does not exist at {{ destination_directory }}/{{ binary_file_name_override }}."
   when:
     - binary_file_name_override is defined
+    - binary_url | default('', true) | length > 0
     - not binary_override_file_stat.stat.exists

--- a/tasks/systemd/setup.yml
+++ b/tasks/systemd/setup.yml
@@ -1,6 +1,7 @@
 ---
 - name: Download service binary
   ansible.builtin.include_tasks: ../common/download-binary.yml
+  when: binary_url | default('', true) | length > 0
 
 - name: Start service systemd unit
   ansible.builtin.include_role:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Binary download operations in common and systemd workflows now include input validation to conditionally skip execution when the required URL parameter is not supplied, improving overall system robustness and preventing unnecessary failed operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->