### PR TITLE
docs: refine AGENTS.md for accuracy and succinctness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,65 +1,71 @@
 # AGENTS.md
 
-## Cursor Cloud specific instructions
+## Overview
 
-This repository is the **Ansible Galaxy role `basic_service`** (plus a Helm chart). There is no long-running web app; development means **linting** and **Molecule integration tests** (see `.github/workflows/CI.yaml`).
+Ansible Galaxy role **`basic_service`** (playbooks reference it as `basic-service`) plus a Helm chart. No long-running app—development is **lint** and **Molecule** tests (`.github/workflows/CI.yaml`).
 
-### One-time VM setup (not in the update script)
-
-These steps are required on a fresh Cloud Agent VM and are **not** repeated on every session:
-
-1. **Docker Engine** — Install Docker CE with `fuse-overlayfs` storage driver and `iptables-legacy` (standard Cursor Cloud Docker-in-VM pattern). Ensure `dockerd` stays running; if the daemon exits leaving zombie `[dockerd]` processes, remove stale `/var/run/docker*` state and start `sudo /usr/bin/dockerd` in a dedicated tmux session (`dockerd-server`).
-2. **Docker socket access** — `sudo chmod 666 /var/run/docker.sock` (or add the agent user to the `docker` group and use a new shell).
-3. **Role path symlink** — Molecule sets `ANSIBLE_ROLES_PATH` to `../../../../` from each scenario, which resolves to `/` when the repo is checked out as `/workspace`. Create: `sudo ln -sfn /workspace /basic-service` so the role name `basic-service` resolves correctly.
-4. **rsync** — `sudo apt-get install -y rsync` (Molecule Docker driver uses it during `create`).
-5. **Root Python deps for `become`** — Ansible’s `community.docker` modules run under `sudo` and need compatible libraries in **root’s** Python:  
-   `sudo pip install --break-system-packages 'requests==2.31.0' 'urllib3<2' 'docker>=6,<7'`  
-   (Avoids `http+docker` / urllib3 v2 errors with the distro `community.docker` collection.)
-
-### Update script (automatic on session start)
-
-The VM update script only refreshes **Python tooling** (see `SetupVmEnvironment`). It does not start Docker or run tests.
-
-### Lint
-
-From repo root (matches CI):
+## Shell environment
 
 ```bash
 export PATH="$HOME/.local/bin:$PATH"
+```
+
+The session update script (`SetupVmEnvironment`) refreshes Python tooling only; it does not install Docker or run tests.
+
+## One-time VM setup
+
+Required on a fresh Cloud Agent VM (not repeated each session):
+
+1. **Docker** — Docker CE with `fuse-overlayfs` and `iptables-legacy`. Keep `dockerd` running (e.g. tmux session `dockerd-server`). If the daemon dies with zombie `[dockerd]` processes, clear stale `/var/run/docker*` and run `sudo /usr/bin/dockerd`.
+2. **Socket access** — `sudo chmod 666 /var/run/docker.sock` (or add the agent user to the `docker` group in a new shell).
+3. **Role symlink** — Molecule sets `ANSIBLE_ROLES_PATH` to `../../../../` (filesystem root when the repo is `/workspace`). Run `sudo ln -sfn /workspace /basic-service` so `role: basic-service` resolves.
+4. **rsync** — `sudo apt-get install -y rsync` (Molecule Docker driver).
+5. **Root pip deps** — `community.docker` under `become` needs root Python packages:  
+   `sudo pip install --break-system-packages 'requests==2.31.0' 'urllib3<2' 'docker>=6,<7'`
+
+## Lint
+
+From repo root:
+
+```bash
 yamllint --config-file ./tests/yaml-lint.yml .
 ansible-lint --config-file ./tests/ansible-lint.yml .
 ```
 
-### Tests (Molecule)
+## Molecule tests
 
 From `tests/`:
 
 ```bash
-export PATH="$HOME/.local/bin:$PATH"
 cd tests
-molecule test -s container-basic   # or any CI scenario name
+molecule test -s container-basic   # or any scenario name below
 ```
 
-CI scenarios: `systemd-basic`, `systemd-full`, `systemd-uninstall`, `container-basic`, `container-full`, `container-uninstall`.
+**CI scenarios:** `systemd-basic`, `systemd-full`, `systemd-uninstall`, `container-basic`, `container-full`, `container-uninstall`.
 
-**Cloud VM caveats:**
+**Local-only scenarios** (not in CI): `install-basic`, `install-uninstall`.
 
-- **Container scenarios** (`container-basic`, etc.) use `docker:24.0.5-dind` with the host Docker socket. Starting nested containers may fail with cgroup v2 “threaded mode” unless the daemon or containers use host cgroup namespace (`docker run --cgroupns=host`). GitHub Actions `ubuntu-latest` does not hit this; Cursor Cloud VMs often do.
-- **Systemd scenarios** need a healthy privileged instance with `/sys/fs/cgroup` mounted (already in their `molecule.yml`). If the Molecule `instance` container exits immediately, check `docker logs instance` and Docker daemon stability.
-- Inside the Molecule **instance** container, if converge fails on Docker API errors, install root pip deps there too: `docker exec instance pip3 install --break-system-packages 'requests==2.31.0' 'docker>=6,<7'` and `ansible-galaxy collection install community.docker`.
+### Cloud VM caveats
 
-### Quick hello-world (container mode, host Docker)
+- **Container scenarios** use `docker:24.0.5-dind` with the host socket. Nested containers on cgroup v2 may need host cgroup namespace (`docker run --cgroupns=host` or `cgroupns_mode: host` in playbooks). GHA `ubuntu-latest` usually avoids this; Cloud VMs often do not.
+- **Systemd / install scenarios** use a privileged instance with `/sys/fs/cgroup` and `cgroupns_mode: host` in `molecule.yml`. If `instance` exits immediately, check `docker logs instance` and daemon health.
+- **Inside `instance`**, Docker API failures may need:  
+  `docker exec instance pip3 install --break-system-packages 'requests==2.31.0' 'urllib3<2' 'docker>=6,<7'`  
+  and `ansible-galaxy collection install community.docker`.
 
-With Docker running and the `/basic-service` symlink in place:
+### Quick validation (host Docker)
+
+With Docker running and `/basic-service` symlinked:
 
 ```bash
-export PATH="$HOME/.local/bin:$PATH"
-ansible -m community.docker.docker_container -a "name=nginx-hello image=nginx:latest state=started published_ports=8080:80 cgroupns_mode=host" localhost -become
+ansible -m community.docker.docker_container \
+  -a "name=nginx-hello image=nginx:latest state=started published_ports=8080:80 cgroupns_mode=host" \
+  localhost -become
 curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8080/
 ```
 
-This exercises the same `community.docker` stack the role uses for `setup_mode: container` (the role itself does not set `cgroupns_mode`; full `molecule test` on Cloud VMs may still need the cgroup workarounds above).
+Exercises the same stack as `setup_mode: container` (the role does not set `cgroupns_mode`; full Molecule runs may still need cgroup workarounds above).
 
-### Kubernetes / Helm
+## Kubernetes / Helm
 
-`setup_mode: k8s` is **not** covered by CI. It requires a live cluster, `KUBECONFIG`, `KUBE_CONTEXT`, Helm, and `kubernetes.core` (see root `README.md` and `helm/README.md`).
+`setup_mode: k8s` is not in CI. Requires a cluster, `KUBECONFIG`, `KUBE_CONTEXT`, Helm, and `kubernetes.core` (see `README.md`, `helm/README.md`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reviews and tightens `AGENTS.md` (Cursor Cloud agent instructions) for correctness, consistency with the repo, and brevity.

## Changes

- **Single PATH block** — Avoid repeating `export PATH=...` in every command section.
- **Role naming** — Clarify Galaxy name `basic_service` vs playbook role `basic-service` and why the `/basic-service` symlink is needed.
- **Scenario coverage** — List `install-basic` and `install-uninstall` as local-only (present in repo, omitted from CI matrix).
- **Dependency parity** — Instance-container pip install now includes `urllib3<2` to match host setup.
- **Cgroup notes** — Note that systemd/install Molecule configs already set `cgroupns_mode: host`; shorten container caveat text.
- **Structure** — Flatten redundant subheadings (`Cursor Cloud specific instructions` → focused sections).

## Verification

Documentation-only change; content cross-checked against `.github/workflows/CI.yaml` and `tests/molecule/*/molecule.yml`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12866add-dfff-4ce0-aa10-0f01f05ff321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12866add-dfff-4ce0-aa10-0f01f05ff321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

