### PR TITLE
feat(container): support binary download and bind-mount into containers

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -27,6 +27,7 @@ jobs:
           - systemd-full
           - systemd-uninstall
           - container-basic
+          - container-binary
           - container-full
           - container-uninstall
           - install-basic

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Configure and operate a basic cloud-native service: running anything from crypto
 | :-------------: | :--------------------------------------------------------: | :--------------: |
 |     _image_     |             service container image to deploy              |    ` `    |
 |     _network_mode_     |             container network to attach ([more info](https://docs.ansible.com/ansible/latest/collections/community/docker/docker_container_module.html#parameter-network_mode))              |    `bridge `    |
+|     _binary_url_     |             URL of the binary file or archive to download and bind-mount into the container              |    ` `    |
+|     _binary_file_name_override_     |             Override the binary file name after moving it to the destination directory              |    ` `    |
+|    _binary_strip_components_     | Strip NUMBER leading components/directories from file names on extraction | `0` |
+|     _destination_directory_     |             host directory where the binary file will be placed after downloading/extracting              |    `/usr/local/bin`    |
+|     _binary_app_path_     |             in-container mount path for the downloaded binary directory              |    `<destination_directory>`    |
 
 ### Systemd
 
@@ -183,6 +188,42 @@ See [requirements.yml](./requirements.yml) for the full list (includes `ansible-
         cpus: 0.5
         memory: 5g
         network_mode: host
+```
+
+- Run a downloaded binary inside a container (e.g. Prometheus from a release archive):
+
+```yaml
+- name: Configure Prometheus in a container
+  hosts: Monitoring
+  become: true
+  roles:
+    - role: basic-service
+      vars:
+        setup_mode: container
+        name: prometheus
+        image: debian:bookworm-slim
+        binary_url: https://github.com/prometheus/prometheus/releases/download/v2.47.0/prometheus-2.47.0.linux-amd64.tar.gz
+        binary_strip_components: 1
+        binary_file_name_override: prometheus
+        destination_directory: /usr/local/bin
+        command: >
+          /usr/local/bin/prometheus --config.file=/etc/prometheus/prometheus.yml
+          --storage.tsdb.path=/prometheus --web.listen-address=0.0.0.0:9090
+        ports:
+          prometheus:
+            ingressPort: 9090
+            servicePort: 9090
+        host_data_dir: /var/lib/prometheus
+        config:
+          prometheus.yml:
+            destinationPath: /etc/prometheus/prometheus.yml
+            data: |
+              global:
+                scrape_interval: 15s
+        data_dirs:
+          prometheus-data:
+            hostPath: /var/lib/prometheus/data
+            appPath: /prometheus
 ```
 
 - Install a tool (e.g. `curl`):

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,6 +66,7 @@ uninstall: false
 ### Container ###
 image:
 network_mode: bridge
+# binary_app_path: /usr/local/bin
 _volume_list: []
 _port_list: []
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -59,7 +59,7 @@
     path: "/tmp/{{ _derived_binary_basename }}"
     state: absent
   when:
-    - setup_mode in ['systemd', 'install']
+    - setup_mode in ['systemd', 'install', 'container']
     - binary_url is defined
     - _derived_binary_basename | length > 0
     - _derived_binary_basename != "."
@@ -72,7 +72,7 @@
     path: "{{ destination_directory }}/{{ _derived_binary_name }}"
     state: absent
   when:
-    - setup_mode in ['systemd', 'install']
+    - setup_mode in ['systemd', 'install', 'container']
     - destination_directory is defined
     - _derived_binary_name | length > 0
     - _derived_binary_name != "."

--- a/tasks/common/facts-container.yml
+++ b/tasks/common/facts-container.yml
@@ -24,6 +24,17 @@
   loop_control:
     label: "{{ item.key }}"
 
+- name: Add binary destination directory to container volume list
+  ansible.builtin.set_fact:
+    _volume_list: >-
+      {{
+        _volume_list +
+        [
+          destination_directory + ':' + (binary_app_path | default(destination_directory))
+        ]
+      }}
+  when: binary_url | default('', true) | length > 0
+
 - name: Determine service container port list
   ansible.builtin.set_fact:
     _port_list: >-

--- a/tasks/container/setup.yml
+++ b/tasks/container/setup.yml
@@ -4,15 +4,19 @@
   when: binary_url | default('', true) | length > 0
 
 - name: Start service container
-  community.docker.docker_container:
-    name: "{{ name }}"
-    image: "{{ image }}"
-    user: root
-    command: "{{ command | default(omit) }}"
-    env: "{{ config_env }}"
-    published_ports: "{{ _port_list }}"
-    network_mode: "{{ network_mode }}"
-    volumes: "{{ _volume_list }}"
-    cpus: "{{ cpus }}"
-    memory: "{{ memory }}"
-    restart_policy: "{{ restart_policy }}"
+  community.docker.docker_container: >-
+    {{
+      {
+        'name': name,
+        'image': image,
+        'user': 'root',
+        'env': config_env,
+        'published_ports': _port_list,
+        'network_mode': network_mode,
+        'volumes': _volume_list,
+        'cpus': cpus,
+        'memory': memory,
+        'restart_policy': restart_policy,
+      }
+      | combine({'command': command} if command is defined and command | length > 0 else {})
+    }}

--- a/tasks/container/setup.yml
+++ b/tasks/container/setup.yml
@@ -1,4 +1,8 @@
 ---
+- name: Download service binary
+  ansible.builtin.include_tasks: ../common/download-binary.yml
+  when: binary_url | default('', true) | length > 0
+
 - name: Start service container
   community.docker.docker_container:
     name: "{{ name }}"

--- a/tests/molecule/container-binary/converge.yml
+++ b/tests/molecule/container-binary/converge.yml
@@ -14,9 +14,7 @@
         binary_file_name_override: jq-tool
         destination_directory: /opt/binaries
         binary_app_path: /opt/binaries
-        command:
-          - /bin/sleep
-          - infinity
+        command: sleep infinity
         cpus: 0.5
         memory: 128M
         network_mode: bridge

--- a/tests/molecule/container-binary/converge.yml
+++ b/tests/molecule/container-binary/converge.yml
@@ -1,0 +1,20 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    ansible_user: root
+  roles:
+    - role: basic-service
+      vars:
+        setup_mode: container
+        name: jq-container
+        image: alpine:3.18
+        binary_url: https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
+        binary_file_name_override: jq-tool
+        destination_directory: /usr/local/bin
+        command: sh -c "/usr/local/bin/jq-tool --version && exec sleep infinity"
+        cpus: 0.5
+        memory: 128M
+        network_mode: bridge
+        restart_policy: on-failure

--- a/tests/molecule/container-binary/converge.yml
+++ b/tests/molecule/container-binary/converge.yml
@@ -9,11 +9,12 @@
       vars:
         setup_mode: container
         name: jq-container
-        image: alpine:3.18
+        image: debian:bookworm-slim
         binary_url: https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
         binary_file_name_override: jq-tool
-        destination_directory: /usr/local/bin
-        command: sh -c "/usr/local/bin/jq-tool --version && exec sleep infinity"
+        destination_directory: /opt/binaries
+        binary_app_path: /opt/binaries
+        command: sleep infinity
         cpus: 0.5
         memory: 128M
         network_mode: bridge

--- a/tests/molecule/container-binary/converge.yml
+++ b/tests/molecule/container-binary/converge.yml
@@ -9,10 +9,10 @@
       vars:
         setup_mode: container
         name: jq-container
-        image: debian:bookworm-slim
+        image: alpine:3.18
         binary_url: https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
         binary_file_name_override: jq-tool
-        destination_directory: /opt/binaries
+        destination_directory: /tmp/molecule-binary
         binary_app_path: /opt/binaries
         command: sleep infinity
         cpus: 0.5

--- a/tests/molecule/container-binary/converge.yml
+++ b/tests/molecule/container-binary/converge.yml
@@ -9,7 +9,7 @@
       vars:
         setup_mode: container
         name: jq-container
-        image: alpine:3.18
+        image: debian:bookworm-slim
         binary_url: https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
         binary_file_name_override: jq-tool
         destination_directory: /opt/binaries

--- a/tests/molecule/container-binary/converge.yml
+++ b/tests/molecule/container-binary/converge.yml
@@ -9,12 +9,14 @@
       vars:
         setup_mode: container
         name: jq-container
-        image: debian:bookworm-slim
+        image: alpine:3.18
         binary_url: https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
         binary_file_name_override: jq-tool
         destination_directory: /opt/binaries
         binary_app_path: /opt/binaries
-        command: sleep infinity
+        command:
+          - /bin/sleep
+          - infinity
         cpus: 0.5
         memory: 128M
         network_mode: bridge

--- a/tests/molecule/container-binary/molecule.yml
+++ b/tests/molecule/container-binary/molecule.yml
@@ -1,0 +1,35 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: docker:24.0.5-dind
+    privileged: true
+    network_mode: host
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: ../prepare-docker.yml
+  env:
+    ANSIBLE_ROLES_PATH: "../../../../"
+    ANSIBLE_ALLOW_BROKEN_CONDITIONALS: "True"
+verifier:
+  name: testinfra
+  directory: ./tests
+scenario:
+  name: container-binary
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/tests/molecule/container-binary/molecule.yml
+++ b/tests/molecule/container-binary/molecule.yml
@@ -10,6 +10,8 @@ platforms:
     network_mode: host
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      # Share binary staging dir with the host Docker daemon (socket is host-mounted).
+      - /tmp/molecule-binary:/tmp/molecule-binary
 provisioner:
   name: ansible
   playbooks:

--- a/tests/molecule/container-binary/tests/test_container_binary.py
+++ b/tests/molecule/container-binary/tests/test_container_binary.py
@@ -1,6 +1,7 @@
 def test_container_running(host):
     container = host.docker("jq-container")
     assert container.is_running
+    assert container.inspect()["State"]["Status"] == "running"
 
 
 def test_binary_downloaded_on_host(host):
@@ -11,14 +12,13 @@ def test_binary_downloaded_on_host(host):
 
 
 def test_binary_mounted_in_container(host):
-    container = host.get_host("docker://jq-container")
-    binary = container.file("/opt/binaries/jq-tool")
-    assert binary.exists, "The service binary is not mounted in the container."
-    assert binary.mode & 0o111, "The mounted binary is not executable."
+    container = host.docker("jq-container")
+    mounts = container.inspect()["Mounts"]
+    binary_mounts = [m for m in mounts if m.get("Destination") == "/opt/binaries"]
+    assert len(binary_mounts) == 1, "Binary directory is not mounted in the container."
 
 
 def test_binary_executes_in_container(host):
-    container = host.get_host("docker://jq-container")
-    result = container.run("/opt/binaries/jq-tool --version")
+    result = host.run("docker exec jq-container /opt/binaries/jq-tool --version")
     assert result.rc == 0, f"jq failed to execute: {result.stderr}"
     assert "jq-" in result.stdout, "jq version output was unexpected."

--- a/tests/molecule/container-binary/tests/test_container_binary.py
+++ b/tests/molecule/container-binary/tests/test_container_binary.py
@@ -1,8 +1,6 @@
 def test_container_running(host):
     container = host.docker("jq-container")
     assert container.is_running
-    status = container.inspect()["State"]["Status"]
-    assert status == "running", f"Container status is '{status}', expected 'running'."
 
 
 def test_binary_downloaded_on_host(host):
@@ -13,15 +11,14 @@ def test_binary_downloaded_on_host(host):
 
 
 def test_binary_mounted_in_container(host):
-    container = host.docker("jq-container")
-    mounts = container.inspect()["Mounts"]
-    binary_mounts = [m for m in mounts if m.get("Destination") == "/opt/binaries"]
-    assert len(binary_mounts) == 1, "Binary directory is not mounted in the container."
-    assert binary_mounts[0]["Type"] == "bind"
-    assert binary_mounts[0]["RW"] is True
+    container = host.get_host("docker://jq-container")
+    binary = container.file("/opt/binaries/jq-tool")
+    assert binary.exists, "The service binary is not mounted in the container."
+    assert binary.mode & 0o111, "The mounted binary is not executable."
 
 
 def test_binary_executes_in_container(host):
-    result = host.run("docker exec jq-container /opt/binaries/jq-tool --version")
+    container = host.get_host("docker://jq-container")
+    result = container.run("/opt/binaries/jq-tool --version")
     assert result.rc == 0, f"jq failed to execute: {result.stderr}"
     assert "jq-" in result.stdout, "jq version output was unexpected."

--- a/tests/molecule/container-binary/tests/test_container_binary.py
+++ b/tests/molecule/container-binary/tests/test_container_binary.py
@@ -1,0 +1,24 @@
+def test_container_running(host):
+    container = host.docker("jq-container")
+    assert container.is_running
+
+
+def test_binary_downloaded_on_host(host):
+    binary = host.file("/usr/local/bin/jq-tool")
+    assert binary.exists, "The service binary does not exist on the host."
+    assert binary.is_file, "The service binary is not a regular file."
+    assert binary.mode & 0o111, "The service binary is not executable."
+
+
+def test_binary_mounted_in_container(host):
+    container = host.get_host("docker://jq-container")
+    binary = container.file("/usr/local/bin/jq-tool")
+    assert binary.exists, "The service binary is not mounted in the container."
+    assert binary.mode & 0o111, "The mounted binary is not executable."
+
+
+def test_binary_executes_in_container(host):
+    container = host.get_host("docker://jq-container")
+    result = container.run("/usr/local/bin/jq-tool --version")
+    assert result.rc == 0, f"jq failed to execute: {result.stderr}"
+    assert "jq-" in result.stdout, "jq version output was unexpected."

--- a/tests/molecule/container-binary/tests/test_container_binary.py
+++ b/tests/molecule/container-binary/tests/test_container_binary.py
@@ -5,7 +5,7 @@ def test_container_running(host):
 
 
 def test_binary_downloaded_on_host(host):
-    binary = host.file("/opt/binaries/jq-tool")
+    binary = host.file("/tmp/molecule-binary/jq-tool")
     assert binary.exists, "The service binary does not exist on the host."
     assert binary.is_file, "The service binary is not a regular file."
     assert binary.mode & 0o111, "The service binary is not executable."

--- a/tests/molecule/container-binary/tests/test_container_binary.py
+++ b/tests/molecule/container-binary/tests/test_container_binary.py
@@ -1,24 +1,26 @@
 def test_container_running(host):
     container = host.docker("jq-container")
     assert container.is_running
+    status = container.inspect()["State"]["Status"]
+    assert status == "running", f"Container status is '{status}', expected 'running'."
 
 
 def test_binary_downloaded_on_host(host):
-    binary = host.file("/usr/local/bin/jq-tool")
+    binary = host.file("/opt/binaries/jq-tool")
     assert binary.exists, "The service binary does not exist on the host."
     assert binary.is_file, "The service binary is not a regular file."
     assert binary.mode & 0o111, "The service binary is not executable."
 
 
 def test_binary_mounted_in_container(host):
-    container = host.get_host("docker://jq-container")
-    binary = container.file("/usr/local/bin/jq-tool")
-    assert binary.exists, "The service binary is not mounted in the container."
-    assert binary.mode & 0o111, "The mounted binary is not executable."
+    container = host.docker("jq-container")
+    mounts = container.inspect()["Mounts"]
+    binary_mounts = [m for m in mounts if m.get("Destination") == "/opt/binaries"]
+    assert len(binary_mounts) == 1, "Binary directory is not mounted in the container."
+    assert binary_mounts[0]["Source"] == "/opt/binaries"
 
 
 def test_binary_executes_in_container(host):
-    container = host.get_host("docker://jq-container")
-    result = container.run("/usr/local/bin/jq-tool --version")
+    result = host.run("docker exec jq-container /opt/binaries/jq-tool --version")
     assert result.rc == 0, f"jq failed to execute: {result.stderr}"
     assert "jq-" in result.stdout, "jq version output was unexpected."

--- a/tests/molecule/container-binary/tests/test_container_binary.py
+++ b/tests/molecule/container-binary/tests/test_container_binary.py
@@ -17,7 +17,8 @@ def test_binary_mounted_in_container(host):
     mounts = container.inspect()["Mounts"]
     binary_mounts = [m for m in mounts if m.get("Destination") == "/opt/binaries"]
     assert len(binary_mounts) == 1, "Binary directory is not mounted in the container."
-    assert binary_mounts[0]["Source"] == "/opt/binaries"
+    assert binary_mounts[0]["Type"] == "bind"
+    assert binary_mounts[0]["RW"] is True
 
 
 def test_binary_executes_in_container(host):

--- a/tests/molecule/prepare-docker.yml
+++ b/tests/molecule/prepare-docker.yml
@@ -10,4 +10,4 @@
       raw: apk add --no-cache sudo python3 py3-pip
 
     - name: Install python dependencies
-      raw: pip3 install --break-system-packages --ignore-installed PyYAML pytest-testinfra molecule-docker
+      raw: pip3 install --break-system-packages --ignore-installed PyYAML pytest-testinfra molecule-docker 'requests==2.31.0' 'urllib3<2' 'docker>=6,<7'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Container deploy mode (`setup_mode: container`) now supports downloading a binary or archive from a URL and bind-mounting it into a container for execution — while still using a specified base image.

This brings container mode in line with the existing `binary_url`, `binary_strip_components`, `binary_file_name_override`, and `destination_directory` variables already used by systemd and install modes.

## Changes

- **Binary download**: `tasks/container/setup.yml` includes the shared `download-binary.yml` task when `binary_url` is set
- **Volume mount**: `facts-container.yml` bind-mounts `destination_directory` into the container at `binary_app_path` (defaults to `destination_directory`)
- **Uninstall**: Binary cleanup handlers now run for `setup_mode: container`
- **Docs**: README updated with container binary variables and a Prometheus example
- **Tests**: New `container-binary` Molecule scenario (jq static binary in Alpine)
- **CI**: Added `container-binary` to the Molecule matrix
- **Molecule fix**: Install pinned `docker`/`requests`/`urllib3` in `prepare-docker.yml` so `community.docker` works inside dind instances

## Usage example

```yaml
setup_mode: container
name: prometheus
image: debian:bookworm-slim
binary_url: https://github.com/prometheus/prometheus/releases/download/v2.47.0/prometheus-2.47.0.linux-amd64.tar.gz
binary_strip_components: 1
binary_file_name_override: prometheus
destination_directory: /usr/local/bin
command: /usr/local/bin/prometheus --config.file=/etc/prometheus/prometheus.yml
```

## Testing

- `yamllint` and `ansible-lint` pass
- Manual validation: downloaded jq binary, bind-mounted `/usr/local/bin`, executed successfully inside Alpine container
- Molecule `container-binary` scenario added (runs in CI on `ubuntu-latest`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5256ca8-62ff-47c6-b474-0a275257e65b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5256ca8-62ff-47c6-b474-0a275257e65b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

