### PR TITLE
chore(cursor): add cursor-cloud rule

### DIFF
--- a/.cursor/rules/cursor-cloud.mdc
+++ b/.cursor/rules/cursor-cloud.mdc
@@ -1,0 +1,37 @@
+---
+description: Ansible Galaxy basic_service role — Cursor Cloud VM setup, lint, Molecule, and Helm validation
+alwaysApply: false
+---
+
+# basic-service — Cursor Cloud
+
+Ansible Galaxy role **`basic_service`** + Helm chart. Dev workflow: lint and Molecule (`.github/workflows/CI.yaml`).
+
+## VM setup (one-time)
+
+1. Docker CE + `fuse-overlayfs`; keep `dockerd` running
+2. `sudo chmod 666 /var/run/docker.sock`
+3. `sudo ln -sfn /workspace /basic-service` (Molecule role path)
+4. `sudo apt-get install -y rsync`
+5. Root pip: `sudo pip install --break-system-packages 'requests==2.31.0' 'urllib3<2' 'docker>=6,<7'`
+
+## Lint
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+yamllint --config-file ./tests/yaml-lint.yml .
+ansible-lint --config-file ./tests/ansible-lint.yml .
+./tests/helm-validate.sh
+```
+
+## Molecule
+
+```bash
+cd tests && molecule test -s container-basic
+```
+
+CI scenarios: `systemd-basic`, `container-basic`, `container-binary-service`, `k8s-basic`, etc.
+
+## cgroup caveat
+
+Cloud VMs on cgroup v2 may need `cgroupns_mode: host` for container scenarios.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,73 +1,9 @@
 # AGENTS.md
 
-## Overview
-
-Ansible Galaxy role **`basic_service`** (playbooks reference it as `basic-service`) plus a Helm chart. No long-running app—development is **lint** and **Molecule** tests (`.github/workflows/CI.yaml`).
-
-## Shell environment
-
-```bash
-export PATH="$HOME/.local/bin:$PATH"
-```
-
-The session update script (`SetupVmEnvironment`) refreshes Python tooling only; it does not install Docker or run tests.
-
-## One-time VM setup
-
-Required on a fresh Cloud Agent VM (not repeated each session):
-
-1. **Docker** — Docker CE with `fuse-overlayfs` and `iptables-legacy`. Keep `dockerd` running (e.g. tmux session `dockerd-server`). If the daemon dies with zombie `[dockerd]` processes, clear stale `/var/run/docker*` and run `sudo /usr/bin/dockerd`.
-2. **Socket access** — `sudo chmod 666 /var/run/docker.sock` (or add the agent user to the `docker` group in a new shell).
-3. **Role symlink** — Molecule sets `ANSIBLE_ROLES_PATH` to `../../../../` (filesystem root when the repo is `/workspace`). Run `sudo ln -sfn /workspace /basic-service` so `role: basic-service` resolves.
-4. **rsync** — `sudo apt-get install -y rsync` (Molecule Docker driver).
-5. **Root pip deps** — `community.docker` under `become` needs root Python packages:  
-   `sudo pip install --break-system-packages 'requests==2.31.0' 'urllib3<2' 'docker>=6,<7'`
-
-## Lint
-
-From repo root:
+Agent guidance for the `basic_service` Ansible role lives in `.cursor/rules/cursor-cloud.mdc`.
 
 ```bash
 yamllint --config-file ./tests/yaml-lint.yml .
-ansible-lint --config-file ./tests/ansible-lint.yml .
+cd tests && molecule test -s container-basic
+./tests/helm-validate.sh
 ```
-
-## Molecule tests
-
-From `tests/`:
-
-```bash
-cd tests
-molecule test -s container-basic   # or any scenario name below
-```
-
-**CI scenarios:** `systemd-basic`, `systemd-full`, `systemd-uninstall`, `container-basic`, `container-binary`, `container-binary-service`, `container-full`, `container-uninstall`, `install-basic`, `install-uninstall`, `k8s-basic`.
-
-`container-binary` exercises bind-mount mechanics with a short-lived `jq` binary. `container-binary-service` deploys a long-running daemon from a downloaded tarball (Prometheus) with config, data, ports, and readiness checks. `k8s-basic` uses the delegated driver with a local [kind](https://kind.sigs.k8s.io/) cluster to test `setup_mode: k8s` end-to-end.
-
-**Helm validation:** `./tests/helm-validate.sh` (also runs in the lint CI job).
-
-### Cloud VM caveats
-
-- **Container scenarios** use `docker:24.0.5-dind` with the host socket. Nested containers on cgroup v2 may need host cgroup namespace (`docker run --cgroupns=host` or `cgroupns_mode: host` in playbooks). GHA `ubuntu-latest` usually avoids this; Cloud VMs often do not.
-- **Systemd / install scenarios** use a privileged instance with `/sys/fs/cgroup` and `cgroupns_mode: host` in `molecule.yml`. If `instance` exits immediately, check `docker logs instance` and daemon health.
-- **Inside `instance`**, Docker API failures may need:  
-  `docker exec instance pip3 install --break-system-packages 'requests==2.31.0' 'urllib3<2' 'docker>=6,<7'`  
-  and `ansible-galaxy collection install community.docker`.
-
-### Quick validation (host Docker)
-
-With Docker running and `/basic-service` symlinked:
-
-```bash
-ansible -m community.docker.docker_container \
-  -a "name=nginx-hello image=nginx:latest state=started published_ports=8080:80 cgroupns_mode=host" \
-  localhost -become
-curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8080/
-```
-
-Exercises the same stack as `setup_mode: container` (the role does not set `cgroupns_mode`; full Molecule runs may still need cgroup workarounds above).
-
-## Kubernetes / Helm
-
-`k8s-basic` provisions kind on the CI runner (Docker required) and sets `KUBECONFIG` for the role. Chart-only validation also runs via `./tests/helm-validate.sh`. Manual deploys still need `KUBECONFIG`, `KUBE_CONTEXT`, Helm, and `kubernetes.core` (see `README.md`, `helm/README.md`).


### PR DESCRIPTION
## Summary
- Add `.cursor/rules/cursor-cloud.mdc` for Cloud Agent VM setup, lint, and Molecule
- Stub `AGENTS.md` pointing at the rule

## Test plan
- [ ] Customize shows `cursor-cloud` rule

Made with [Cursor](https://cursor.com)